### PR TITLE
Fix RTP ports handling and improve naming of related MediaManager methods

### DIFF
--- a/desktop_source/desktop_media_manager.cpp
+++ b/desktop_source/desktop_media_manager.cpp
@@ -25,12 +25,18 @@ bool DesktopMediaManager::IsPaused() const {
   return (gst_pipeline_->GetState() != GST_STATE_PLAYING);
 }
 
-void DesktopMediaManager::SetRtpPorts(int port1, int port2) {
+void DesktopMediaManager::SetSinkRtpPorts(int port1, int port2) {
+  sink_port1_ = port1;
+  sink_port2_ = port2;
   gst_pipeline_.reset(new MiracGstTestSource(WFD_DESKTOP, hostname_, port1));
   gst_pipeline_->SetState(GST_STATE_READY);
 }
 
-int DesktopMediaManager::RtpPort() const {
+std::pair<int, int> DesktopMediaManager::SinkRtpPorts() const {
+  return std::pair<int, int>(sink_port1_, sink_port2_);
+}
+
+int DesktopMediaManager::SourceRtpPort() const {
   return gst_pipeline_->UdpSourcePort();
 }
 

--- a/desktop_source/desktop_media_manager.h
+++ b/desktop_source/desktop_media_manager.h
@@ -13,8 +13,9 @@ class DesktopMediaManager : public wfd::MediaManager {
   virtual void Pause() override;
   virtual void Teardown() override;
   virtual bool IsPaused() const override;
-  virtual void SetRtpPorts(int port1, int port2) override;
-  virtual int RtpPort() const override;
+  virtual void SetSinkRtpPorts(int port1, int port2) override;
+  virtual std::pair<int,int> SinkRtpPorts() const override;
+  virtual int SourceRtpPort() const override;
   virtual void SetPresentationUrl(const std::string& url) override;
   virtual std::string PresentationUrl() const override;
   virtual void SetSession(const std::string& session) override;
@@ -23,6 +24,9 @@ class DesktopMediaManager : public wfd::MediaManager {
  private:
   std::string hostname_;
   std::unique_ptr<MiracGstTestSource> gst_pipeline_;
+
+  int sink_port1_;
+  int sink_port2_;
 };
 
 #endif // DESKTOP_MEDIA_MANAGER_H_

--- a/sink/sink_media_manager.cpp
+++ b/sink/sink_media_manager.cpp
@@ -38,12 +38,17 @@ bool SinkMediaManager::IsPaused() const {
   return true;
 }
 
-void SinkMediaManager::SetRtpPorts(int port1, int port2) {
+void SinkMediaManager::SetSinkRtpPorts(int port1, int port2) {
 }
 
-int SinkMediaManager::RtpPort() const {
-  return gst_pipeline_->sink_udp_port();
+std::pair<int,int> SinkMediaManager::SinkRtpPorts() const {
+  return std::pair<int,int>(gst_pipeline_->sink_udp_port(), 0);
 }
+
+int SinkMediaManager::SourceRtpPort() const {
+  return 0;
+}
+
 
 void SinkMediaManager::SetPresentationUrl(const std::string& url) {
   presentation_url_ = url;

--- a/sink/sink_media_manager.h
+++ b/sink/sink_media_manager.h
@@ -35,8 +35,9 @@ class SinkMediaManager : public wfd::MediaManager {
   virtual void Pause() override;
   virtual void Teardown() override;
   virtual bool IsPaused() const override;
-  virtual void SetRtpPorts(int port1, int port2) override;
-  virtual int RtpPort() const override;
+  virtual void SetSinkRtpPorts(int port1, int port2) override;
+  virtual std::pair<int,int> SinkRtpPorts() const override;
+  virtual int SourceRtpPort() const override;
   virtual void SetPresentationUrl(const std::string& url) override;
   virtual std::string PresentationUrl() const override;
   virtual void SetSession(const std::string& session) override;

--- a/wfd/public/media_manager.h
+++ b/wfd/public/media_manager.h
@@ -31,8 +31,9 @@ class MediaManager {
   virtual void Pause() = 0;
   virtual void Teardown() = 0;
   virtual bool IsPaused() const = 0;
-  virtual void SetRtpPorts(int port1, int port2) = 0;
-  virtual int RtpPort() const = 0;
+  virtual void SetSinkRtpPorts(int port1, int port2) = 0;
+  virtual std::pair<int,int> SinkRtpPorts() const = 0;
+  virtual int SourceRtpPort() const = 0;
   virtual void SetPresentationUrl(const std::string& url) = 0;
   virtual std::string PresentationUrl() const = 0;
   virtual void SetSession(const std::string& session) = 0;

--- a/wfd/sink/cap_negotiation_state.cpp
+++ b/wfd/sink/cap_negotiation_state.cpp
@@ -88,7 +88,7 @@ std::unique_ptr<Reply> M3Handler::HandleMessage(Message* message) {
           new_prop.reset(new wfd::CoupledSink());
           reply->payload().add_property(new_prop);
       } else if (*it == wfd::PropertyName::name[wfd::PropertyType::WFD_CLIENT_RTP_PORTS]){
-          new_prop.reset(new wfd::ClientRtpPorts(manager_->RtpPort(), 0));
+          new_prop.reset(new wfd::ClientRtpPorts(manager_->SinkRtpPorts().first, manager_->SinkRtpPorts().second));
           reply->payload().add_property(new_prop);
       } else if (*it == wfd::PropertyName::name[wfd::PropertyType::WFD_I2C]){
           new_prop.reset(new wfd::I2C(0));

--- a/wfd/sink/wfd_session_state.cpp
+++ b/wfd/sink/wfd_session_state.cpp
@@ -40,7 +40,8 @@ class M6Handler final : public SequencedMessageSender {
   virtual std::unique_ptr<Message> CreateMessage() override {
     auto setup = new Setup(manager_->PresentationUrl());
     auto transport = new TransportHeader();
-    transport->set_client_port(manager_->RtpPort());
+    // we assume here that there is no coupled secondary sink
+    transport->set_client_port(manager_->SinkRtpPorts().first);
 
     setup->header().set_transport(transport);
     setup->header().set_cseq(send_cseq_++);

--- a/wfd/source/cap_negotiation_state.cpp
+++ b/wfd/source/cap_negotiation_state.cpp
@@ -70,7 +70,7 @@ bool M3Handler::HandleReply(Reply* reply) {
   auto prop = reply->payload().get_property(WFD_CLIENT_RTP_PORTS);
   auto ports = static_cast<ClientRtpPorts*>(prop.get());
   assert(ports);
-  manager_->SetRtpPorts(ports->rtp_port_0(), ports->rtp_port_1());
+  manager_->SetSinkRtpPorts(ports->rtp_port_0(), ports->rtp_port_1());
   return true;
 }
 
@@ -78,7 +78,7 @@ std::unique_ptr<Message> M4Handler::CreateMessage() {
   SetParameter* set_param = new SetParameter("rtsp://localhost/wfd1.0");
   set_param->header().set_cseq(send_cseq_++);
   set_param->payload().add_property(
-      std::shared_ptr<Property>(new ClientRtpPorts(1028,0)));
+      std::shared_ptr<Property>(new ClientRtpPorts(manager_->SinkRtpPorts().first,manager_->SinkRtpPorts().second)));
   set_param->payload().add_property(
       std::shared_ptr<Property>(new PresentationUrl(
           "rtsp://127.0.0.1/wfd1.0/streamid=0",

--- a/wfd/source/wfd_session_state.cpp
+++ b/wfd/source/wfd_session_state.cpp
@@ -61,6 +61,13 @@ class M6Handler final : public MessageReceiver<Request::M6> {
     auto reply = std::unique_ptr<Reply>(new Reply(200));
     // todo: generate unique session id
     reply->header().set_session("abcdefg123456");
+
+    auto transport = new TransportHeader();
+    // we assume here that there is no coupled secondary sink
+    transport->set_client_port(manager_->SinkRtpPorts().first);
+    transport->set_server_port(manager_->SourceRtpPort());
+    reply->header().set_transport(transport);
+
     return std::move(reply);
   }
 };


### PR DESCRIPTION
Particularly:
- M4 request needs to use the same ports as M3 response
- M6 response must include a Transport header with both the Source UDP port
  and the Sink UDP port

I also tried to split MediaManager into SourceMediaManager and SinkMediaManager, but too many places in the state machine code assume that it is a single class, so I had to abandon the idea. I think eventually we will have to do it, after MediaManager grows too many methods that are either source- or sink- specific.
