### PR TITLE
Add WDS_INSTALL_TESTS option to install test programs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,8 @@ set(WDS_VERSION_PATCH 0)
 
 enable_testing()
 
+option(WDS_INSTALL_TESTS "Install test programs" off)
+
 include(GNUInstallDirs)
 
 add_subdirectory(data)

--- a/desktop_source/CMakeLists.txt
+++ b/desktop_source/CMakeLists.txt
@@ -21,3 +21,7 @@ include_directories(${GST_INCLUDE_DIRS})
 
 add_executable(desktop-source-test main.cpp source-app.cpp mirac_broker_source.cpp desktop_media_manager.cpp)
 target_link_libraries (desktop-source-test  mirac wds p2p ${GIO_LIBRARIES} ${GST_LIBRARIES})
+
+if (WDS_INSTALL_TESTS)
+  install(PROGRAMS desktop-source-test DESTINATION ${CMAKE_INSTALL_FULL_BINDIR})
+endif()

--- a/libwds/rtsp/tests/CMakeLists.txt
+++ b/libwds/rtsp/tests/CMakeLists.txt
@@ -9,6 +9,10 @@ target_link_libraries (test-wds)
 
 add_test(WfdTest test-wds)
 
+if (WDS_INSTALL_TESTS)
+  install(PROGRAMS test-wds DESTINATION ${CMAKE_INSTALL_FULL_BINDIR})
+endif()
+
 OPTION(WDS_FUZZER "Binary that is used for fuzzer tests." OFF)
 IF(WDS_FUZZER)
 add_executable(wdsfuzzer wdsfuzzer.cpp $<TARGET_OBJECTS:wdsrtsp> $<TARGET_OBJECTS:wdscommon>)

--- a/mirac_network/CMakeLists.txt
+++ b/mirac_network/CMakeLists.txt
@@ -24,3 +24,7 @@ target_link_libraries (network-test ${GLIB2_LIBRARIES} mirac)
 
 add_executable(gst-test gst-test.cpp)
 target_link_libraries (gst-test mirac wds ${GLIB2_LIBRARIES} ${GIO_LIBRARIES} ${GST_LIBRARIES})
+
+if (WDS_INSTALL_TESTS)
+  install(PROGRAMS network-test gst-test DESTINATION ${CMAKE_INSTALL_FULL_BINDIR})
+endif()

--- a/p2p/CMakeLists.txt
+++ b/p2p/CMakeLists.txt
@@ -18,3 +18,7 @@ add_executable(test-ie test-ie.cpp)
 target_link_libraries (test-ie p2p ${GIO_LIBRARIES})
 
 add_test(InformationElementTest test-ie)
+
+if (WDS_INSTALL_TESTS)
+  install(PROGRAMS test-ie DESTINATION ${CMAKE_INSTALL_FULL_BINDIR})
+endif()

--- a/sink/CMakeLists.txt
+++ b/sink/CMakeLists.txt
@@ -20,3 +20,7 @@ include_directories(${GST_INCLUDE_DIRS})
 
 add_executable(sink-test main.cpp sink-app.cpp sink.cpp gst_sink_media_manager.cpp)
 target_link_libraries (sink-test mirac wds p2p ${GIO_LIBRARIES} ${GST_LIBRARIES})
+
+if (WDS_INSTALL_TESTS)
+  install(PROGRAMS sink-test DESTINATION ${CMAKE_INSTALL_FULL_BINDIR})
+endif()


### PR DESCRIPTION
I added this option to be able to install the following binaries:
test-wds, test-ie, network-test, gst-test, sink-testm desktop-source-test
with _make install_ if we set **WDS_INSTALL_TESTS** to **on**.
