### PR TITLE
Fix video format sorting function

### DIFF
--- a/libwds/common/video_format.cpp
+++ b/libwds/common/video_format.cpp
@@ -152,10 +152,10 @@ std::pair<unsigned, unsigned> get_resolution(const H264VideoFormat& format) {
 
 bool video_format_sort_func(const H264VideoFormat& a, const H264VideoFormat& b) {
   if (get_quality_info(a).weight != get_quality_info(b).weight)
-    return get_quality_info(a).weight < get_quality_info(b).weight;
+    return get_quality_info(a).weight > get_quality_info(b).weight;
   if (a.profile != b.profile)
-    return a.profile < b.profile;
-  return a.level < b.level;
+    return a.profile > b.profile;
+  return a.level > b.level;
 }
 
 template <typename RREnum>


### PR DESCRIPTION
Commit 18e54e7dcf4e0a20fc5e220f68626ea7246854d9 (Fix video formats
handling code) converts "operator <" to sort comparison function
itself. However, it doesn't invert the operator inside it. This means
now video formats are sorted from small to large instead of from large
to small.

This commit inverts the operator inside the function, so that it now
sort correctly.